### PR TITLE
Add optional component selection via profile flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,18 @@
 # Change Log
-All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased]
-### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
+All notable changes to this project will be documented in this file. This change log follows the conventions
+of [keepachangelog.com](http://keepachangelog.com/).
 
-## [0.1.1] - 2022-12-30
-### Changed
-- Documentation on how to make the widgets.
-
-### Removed
-- `make-widget-sync` - we're all async, all the time.
+## 0.100.302 - 2026-03-29
 
 ### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
 
-## 0.1.0 - 2022-12-30
+- `+component` flags now switch to opt-in mode (all components disabled by default, only specified ones enabled); `-component` flags retain opt-out mode.
+
+## 0.100.301 - 2026-03-29
+
 ### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
 
-[Unreleased]: https://source-host.site/your-name/net.clojars.macielti/common-clj/compare/0.1.1...HEAD
-[0.1.1]: https://source-host.site/your-name/net.clojars.macielti/common-clj/compare/0.1.0...0.1.1
+- Optional component selection via `+/-` profile flags (`datalevin`, `http-server`, `telegram`, `http-client`); all
+  components included by default.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Project Is
+
+A Leiningen template (`net.clojars.macielti/lein-template.microservice`) that scaffolds Clojure microservices. The root project is the template plugin itself; the actual generated project files live under `resources/leiningen/new/microservice/`.
+
+Usage: `lein new net.clojars.macielti/microservice your-new-project-name`
+
+## Commands
+
+### Root template project
+```bash
+lein test          # Run tests
+lein install       # Install template locally
+lein deploy clojars  # Publish to Clojars
+```
+
+### Generated project (inside resources/leiningen/new/microservice/)
+```bash
+lein test                  # Run all tests (unit + integration)
+lein lint                  # clean-ns + format + clj-kondo diagnostics
+lein lint-fix              # Fix linting issues automatically
+lein native                # Build GraalVM native image
+lein uberjar               # Build fat JAR
+```
+
+The `lein lint` alias runs: `clean-ns` → `format` → `diagnostics` (clj-kondo).
+
+## Architecture of the Generated Microservice
+
+The generated service uses **Integrant** for component lifecycle management. The system map in `src/{{name}}/components.clj` wires together:
+
+- `:config` — loads `resources/config.edn` (`:prod` environment)
+- `:datalevin` — embedded Datomic-like database, schema defined in `db/datalevin/config.clj`
+- `:http-client` — httpkit-based HTTP client component
+- `:telegrama/consumer` — Telegram bot polling handler
+- `:routes` — Pedestal route definitions
+- `:service` — Pedestal + Jetty web server
+
+### Source layout (after generation)
+```
+src/{{name}}/
+├── components.clj               # Integrant system entry point
+├── db/datalevin/config.clj      # Database schema
+└── diplomat/
+    ├── http_server.clj          # Pedestal routes
+    ├── http_server/hello_world.clj  # HTTP handlers
+    └── telegram/consumer.clj   # Telegram command handlers
+```
+
+The "diplomat" layer is the interface boundary — HTTP and Telegram handlers live here. Business logic and DB access go in separate namespaces.
+
+### Configuration
+`resources/config.edn` holds environment-keyed config (`:prod`). It is gitignored in generated projects — only a template copy exists in the resources directory.
+
+## Build & Deploy
+
+The generated project uses a two-stage Docker build:
+1. **Build stage** (`oracle.com/graalvm/native-image:23`): runs `lein uberjar` then `lein native` to produce a native binary
+2. **Runtime stage** (`gcr.io/distroless/base`): copies only the native binary
+
+GraalVM reflection config is in `reflect-config.json` (currently covers Jetty's `ServerConnector`).
+
+GitHub Actions workflows (in `.github/workflows/`):
+- `tests.yml` — runs `lein test` on every push
+- `lint.yml` — runs `lein lint` on every push
+- `build.yml` — builds and pushes Docker image to ghcr.io on push to main
+
+## Template Generator
+
+`src/leiningen/new/microservice.clj` defines the `microservice` template function. It uses Leiningen's `render` for variable substitution (`{{name}}`, `{{sanitized}}`). When adding new template files, register them in the `->files` call in this namespace.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,33 @@
 
 ## Usage
 
-If you want to create a new project, use the following command:
+Create a new project with all components included (default):
 
-`lein new net.clojars.macielti/microservice your-new-project-name`
+```bash
+lein new net.clojars.macielti/microservice your-new-project-name
+```
+
+### Selecting components
+
+Use `+component` flags to opt in to specific components only, or `-component` flags to opt out from the default set.
+
+Available components: `datalevin`, `http-server`, `telegram`, `http-client`
+
+> **Note:** `telegram` always requires `http-client` and will enable it automatically.
+
+```bash
+# Only telegram (+ http-client, required by telegram)
+lein new net.clojars.macielti/microservice your-new-project-name -- +telegram
+
+# Only HTTP server and datalevin
+lein new net.clojars.macielti/microservice your-new-project-name -- +http-server +datalevin
+
+# Everything except telegram
+lein new net.clojars.macielti/microservice your-new-project-name -- -telegram
+
+# Everything except telegram and datalevin
+lein new net.clojars.macielti/microservice your-new-project-name -- -telegram -datalevin
+```
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/lein-template.microservice "0.100.300"
+(defproject net.clojars.macielti/lein-template.microservice "0.100.302"
   :description "Leiningen microservice template"
   :url "https://github.com/macielti/microservice-leiningen-template"
 

--- a/resources/leiningen/new/microservice/project.clj
+++ b/resources/leiningen/new/microservice/project.clj
@@ -8,18 +8,23 @@
                       :url  "https://www.eclipse.org/legal/epl-2.0/"}
 
             :dependencies [[org.clojure/clojure "1.12.4"]
+                           {{#datalevin}}
                            [net.clojars.macielti/datalevin "4.0.0"]
+                           {{/datalevin}}
                            [net.clojars.macielti/service "0.1.0"]
                            [net.clojars.macielti/common-clj "46.1.1"]
+                           {{#telegram}}
                            [net.clojars.macielti/telegrama "1.2.1" :exclusions [io.pedestal/pedestal.interceptor]]
+                           {{/telegram}}
+                           {{#http-client}}
                            [net.clojars.macielti/http-client-component "3.2.3"]
-
-                           ;pedestal
+                           {{/http-client}}
+                           {{#http-server}}
                            [io.pedestal/pedestal.service "0.8.1"]
                            [io.pedestal/pedestal.jetty "0.8.1"]
                            [io.pedestal/pedestal.error "0.8.1"]
                            [io.pedestal/pedestal.interceptor "0.8.1"]
-
+                           {{/http-server}}
                            [com.taoensso/timbre "6.8.0"]
 
                            ;GraalVM native image building

--- a/resources/leiningen/new/microservice/resources/config.edn
+++ b/resources/leiningen/new/microservice/resources/config.edn
@@ -1,7 +1,13 @@
-{:prod {:datalevin-uri "/tmp/{{name}}.datalevin"
-        :name          "{{name}}"
-        :service       {:host "0.0.0.0"
-                        :port 8000}
-        :telegram      {:token                 "<bot token>"
-                        :poll-interval-seconds 1
-                        :chat-id               "<chat id>"}}}
+{:prod {:name "{{name}}"
+        {{#datalevin}}
+        :datalevin-uri "/tmp/{{name}}.datalevin"
+        {{/datalevin}}
+        {{#http-server}}
+        :service {:host "0.0.0.0"
+                  :port 8000}
+        {{/http-server}}
+        {{#telegram}}
+        :telegram {:token                 "<bot token>"
+                   :poll-interval-seconds 1
+                   :chat-id               "<chat id>"}
+        {{/telegram}}}}

--- a/resources/leiningen/new/microservice/src/components.clj
+++ b/resources/leiningen/new/microservice/src/components.clj
@@ -1,13 +1,27 @@
 (ns {{name}}.components
   (:require [common-clj.integrant-components.config :as component.config]
+            {{#http-server}}
             [common-clj.integrant-components.routes :as component.routes]
+            {{/http-server}}
+            {{#http-client}}
             [http-client-component.with-httpkit-client :as component.http-client]
+            {{/http-client}}
+            {{#telegram}}
             [telegrama.component :as component.telegrama]
+            {{/telegram}}
+            {{#datalevin}}
             [datalevin.component :as component.datalevin]
+            {{/datalevin}}
             [service.component :as component.service]
+            {{#datalevin}}
             [{{name}}.db.datalevin.config :as datalevin.config]
+            {{/datalevin}}
+            {{#http-server}}
             [{{name}}.diplomat.http-server :as diplomat.http-server]
+            {{/http-server}}
+            {{#telegram}}
             [{{name}}.diplomat.telegram.consumer :as diplomat.telegram.consumer]
+            {{/telegram}}
             [integrant.core :as ig]
             [taoensso.timbre :as timbre]
             [taoensso.timbre.tools.logging])
@@ -16,21 +30,36 @@
 (taoensso.timbre.tools.logging/use-timbre)
 
 (def components
-  {:config      (ig/ref ::component.config/config)
-   :datalevin   (ig/ref ::component.datalevin/datalevin)
-   :http-client (ig/ref ::component.http-client/http-client)})
+  (merge {:config (ig/ref ::component.config/config)}
+         {{#datalevin}}
+         {:datalevin (ig/ref ::component.datalevin/datalevin)}
+         {{/datalevin}}
+         {{#http-client}}
+         {:http-client (ig/ref ::component.http-client/http-client)}
+         {{/http-client}}))
 
 (def arranjo
-  {::component.config/config       {:path "resources/config.edn"
-                                    :env  :prod}
-   ::component.datalevin/datalevin {:schema     datalevin.config/schema
-                                    :components (select-keys components [:config])}
-   ::component.http-client/http-client {:components {:config     (ig/ref ::component.config/config)}}
-   ::component.telegrama/consumer  {:settings   diplomat.telegram.consumer/settings
-                                    :components components}
-   ::component.routes/routes       {:routes diplomat.http-server/routes}
-   ::component.service/service     {:components (merge components
-                                                       {:routes (ig/ref ::component.routes/routes)})}})
+  (merge
+    {::component.config/config {:path "resources/config.edn"
+                                :env  :prod}}
+    {{#datalevin}}
+    {::component.datalevin/datalevin {:schema     datalevin.config/schema
+                                      :components (select-keys components [:config])}}
+    {{/datalevin}}
+    {{#http-client}}
+    {::component.http-client/http-client {:components {:config (ig/ref ::component.config/config)}}}
+    {{/http-client}}
+    {{#telegram}}
+    {::component.telegrama/consumer {:settings   diplomat.telegram.consumer/settings
+                                     :components components}}
+    {{/telegram}}
+    {{#http-server}}
+    {::component.routes/routes {:routes diplomat.http-server/routes}}
+    {{/http-server}}
+    {::component.service/service {:components (merge components
+                                                     {{#http-server}}
+                                                     {:routes (ig/ref ::component.routes/routes)}
+                                                     {{/http-server}})}}))
 
 (defn start-system! []
   (timbre/set-min-level! :debug)

--- a/src/leiningen/new/microservice.clj
+++ b/src/leiningen/new/microservice.clj
@@ -1,32 +1,78 @@
 (ns leiningen.new.microservice
   (:require [leiningen.new.templates :as tmpl]
-            [leiningen.core.main :as main]))
+            [leiningen.core.main :as main]
+            [clojure.string :as str]))
 
 (def render (tmpl/renderer "microservice"))
 
+(def all-components #{:datalevin :http-server :telegram :http-client})
+
+; Component hard dependencies: if key is enabled, all values must also be enabled
+(def component-deps
+  {:telegram #{:http-client}})
+
+(defn parse-flags [flag-args]
+  (let [opt-in?  (some #(str/starts-with? % "+") flag-args)
+        defaults (zipmap all-components (repeat (not opt-in?)))]
+    (reduce
+      (fn [acc flag]
+        (let [[_ sign component-name] (re-matches #"([+-])(.*)" flag)]
+          (if (nil? sign)
+            acc
+            (let [component (keyword component-name)]
+              (if (contains? all-components component)
+                (assoc acc component (= sign "+"))
+                (do (main/warn (str "Unknown component flag: " flag)) acc))))))
+      defaults
+      flag-args)))
+
+(defn- auto-enable [flags component dep]
+  (if (flags dep)
+    flags
+    (do (main/info (str (name component) " requires " (name dep) " — enabling it automatically"))
+        (assoc flags dep true))))
+
+(defn resolve-deps
+  "Enforces component dependencies. If a component is enabled, its required
+  dependencies are auto-enabled with an info message."
+  [flags]
+  (reduce (fn [flags-acc [component required-deps]]
+            (if (flags-acc component)
+              (reduce #(auto-enable %1 component %2) flags-acc required-deps)
+              flags-acc))
+          flags
+          component-deps))
+
 (defn microservice
-  "FIXME: write documentation"
+  "Generate a Clojure microservice. Use +/- flags to include/exclude components:
+   datalevin, http-server, telegram, http-client (all included by default)"
   [& args]
-  (let [name (first args)
-        data {:name      name
-              :sanitized (tmpl/name-to-path name)}]
+  (let [name  (first args)
+        flags (-> (rest args) parse-flags resolve-deps)
+        data  (merge {:name      name
+                      :sanitized (tmpl/name-to-path name)}
+                     flags)]
     (main/info "Generating fresh 'lein new' net.clojars.macielti/microservice project.")
     (main/info "Using '0.0.0.0' as host and '8000' as port, you can change it by editing 'resources/config.edn'")
-    (tmpl/->files data
-                  ["src/{{sanitized}}/components.clj" (render "src/components.clj" data)]
-                  ["src/{{sanitized}}/db/datalevin/config.clj" (render "src/db/datalevin/config.clj" data)]
-                  ["src/{{sanitized}}/diplomat/http_server/hello_world.clj" (render "src/diplomat/http_server/hello_world.clj" data)]
-                  ["src/{{sanitized}}/diplomat/http_server.clj" (render "src/diplomat/http_server.clj" data)]
-                  ["src/{{sanitized}}/diplomat/telegram/consumer.clj" (render "src/diplomat/telegram/consumer.clj" data)]
-                  ["resources/config.edn" (render "resources/config.edn" data)]
-                  ["Dockerfile" (render "Dockerfile" data)]
-                  [".dockerignore" (render "dockerignore" data)]
-                  [".gitignore" (render "gitignore" data)]
-                  ["project.clj" (render "project.clj" data)]
-                  ["reflect-config.json" (render "reflect-config.json" data)]
-                  ["README.md" (render "README.md" data)]
-                  [".clj-kondo/config.edn" (render "clj-kondo/config.edn" data)]
-                  [".lsp/config.edn" (render "lsp/config.edn" data)]
-                  [".github/workflows/lint.yml" (render "github/workflows/lint.yml" data)]
-                  [".github/workflows/tests.yml" (render "github/workflows/tests.yml" data)]
-                  [".github/workflows/build.yml" (render "github/workflows/build.yml" data)])))
+    (apply tmpl/->files data
+           (concat
+             [["src/{{sanitized}}/components.clj" (render "src/components.clj" data)]]
+             (when (:datalevin data)
+               [["src/{{sanitized}}/db/datalevin/config.clj" (render "src/db/datalevin/config.clj" data)]])
+             (when (:http-server data)
+               [["src/{{sanitized}}/diplomat/http_server/hello_world.clj" (render "src/diplomat/http_server/hello_world.clj" data)]
+                ["src/{{sanitized}}/diplomat/http_server.clj" (render "src/diplomat/http_server.clj" data)]])
+             (when (:telegram data)
+               [["src/{{sanitized}}/diplomat/telegram/consumer.clj" (render "src/diplomat/telegram/consumer.clj" data)]])
+             [["resources/config.edn"             (render "resources/config.edn" data)]
+              ["Dockerfile"                        (render "Dockerfile" data)]
+              [".dockerignore"                     (render "dockerignore" data)]
+              [".gitignore"                        (render "gitignore" data)]
+              ["project.clj"                       (render "project.clj" data)]
+              ["reflect-config.json"               (render "reflect-config.json" data)]
+              ["README.md"                         (render "README.md" data)]
+              [".clj-kondo/config.edn"             (render "clj-kondo/config.edn" data)]
+              [".lsp/config.edn"                   (render "lsp/config.edn" data)]
+              [".github/workflows/lint.yml"        (render "github/workflows/lint.yml" data)]
+              [".github/workflows/tests.yml"       (render "github/workflows/tests.yml" data)]
+              [".github/workflows/build.yml"       (render "github/workflows/build.yml" data)]]))))


### PR DESCRIPTION
## Summary

- Users can now pass `+/-` flags when generating a project to choose which components to include
- `+component` switches to opt-in mode — all components disabled, only specified ones enabled
- `-component` uses opt-out mode — all components enabled except the specified ones
- `telegram` automatically enables `http-client` when selected (hard dependency)

## Examples

```bash
# Only telegram (+ http-client, required by telegram)
lein new net.clojars.macielti/microservice my-app -- +telegram

# Everything except telegram
lein new net.clojars.macielti/microservice my-app -- -telegram

# Only HTTP server and datalevin
lein new net.clojars.macielti/microservice my-app -- +http-server +datalevin
```

## Test plan

- [x] `lein new .../microservice my-app` — all components generated
- [x] `lein new .../microservice my-app -- +telegram` — only telegram + http-client generated
- [x] `lein new .../microservice my-app -- -telegram` — all except telegram generated
- [x] `lein new .../microservice my-app -- -telegram -datalevin` — all except telegram and datalevin
- [x] `lein new .../microservice my-app -- +telegram -http-client` — telegram only (http-client auto-enabled despite the flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)